### PR TITLE
Redesign web UI

### DIFF
--- a/packages/web-ui/app/artists/[slug]/loading.tsx
+++ b/packages/web-ui/app/artists/[slug]/loading.tsx
@@ -1,0 +1,17 @@
+import * as skeleton from "@/styles/loading.css";
+
+export default function Loading() {
+  return (
+    <div>
+      <div className={skeleton.skeletonBack} />
+      <div className={skeleton.skeletonHeading} />
+      {Array.from({ length: 8 }, (_, i) => (
+        <div key={i} className={skeleton.skeletonTableRow}>
+          <div className={skeleton.skeletonCell} />
+          <div className={skeleton.skeletonCell} />
+          <div className={skeleton.skeletonCell} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web-ui/app/artists/[slug]/page.tsx
+++ b/packages/web-ui/app/artists/[slug]/page.tsx
@@ -1,54 +1,96 @@
 import { z } from "zod";
-import { Fragment } from "react";
-import { getArtistPlays } from "@/utils/database";
+import Link from "next/link";
+import { getArtistPlays, getArtistPlayCount } from "@/utils/database";
 import format from "date-fns/format";
-import { body } from "@/styles/typography.css";
+import { heading } from "@/styles/typography.css";
+import * as styles from "@/styles/artist-detail.css";
+import { strings } from "@/utils/strings";
+import { StationBadge } from "@/app/components/StationBadge";
+import { Pagination } from "../components/Pagination";
 
-export default async function Artist({
+const PAGE_SIZE = 50;
+
+const paramsSchema = z
+  .object({
+    page: z.string().regex(/^\d+$/).transform(Number).optional(),
+  })
+  .optional();
+
+export default async function ArtistPage({
   params,
+  searchParams,
 }: {
   params: { slug: string };
+  searchParams?: unknown;
 }) {
-  const data = await getArtistPlays(decodeURIComponent(params.slug));
+  const artistName = decodeURIComponent(params.slug);
+  const parsed = paramsSchema.safeParse(searchParams);
+  const page = parsed.success ? parsed.data?.page ?? 0 : 0;
+  const offset = page * PAGE_SIZE;
 
-  const schema = z.array(
-    z.object({
-      artist: z.string(),
-      title: z.string(),
-      time_played: z.string(),
-      station: z.string(),
-      id: z.number(),
-    })
-  );
+  const [plays, totalCount] = await Promise.all([
+    getArtistPlays(artistName, offset, PAGE_SIZE),
+    getArtistPlayCount(artistName),
+  ]);
 
-  const parsed = schema.safeParse(data);
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
-  if (!parsed.success) {
-    return (
-      <div>
-        <h1>Error</h1>
-        <p>{parsed.error.message}</p>
-      </div>
-    );
+  function formatDate(dateStr: string) {
+    return format(new Date(dateStr), "MMM d, yyyy 'at' h:mm a");
   }
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "1fr 1fr 1fr",
-      }}
-    >
-      <div className={body}>Title</div>
-      <div className={body}>Time Played</div>
-      <div className={body}>Station</div>
-      {parsed.data.map(({ title, time_played, station, id }) => (
-        <Fragment key={id}>
-          <div className={body}>{title}</div>
-          <div className={body}>{format(new Date(time_played), "PP p")}</div>
-          <div className={body}>{station}</div>
-        </Fragment>
-      ))}
+    <div>
+      <Link href="/artists" className={styles.backLink}>
+        {strings.allArtists}
+      </Link>
+
+      <div className={styles.headerRow}>
+        <h1 className={heading}>{artistName}</h1>
+        <span className={styles.playCount}>
+          {totalCount.toLocaleString("en-US")}{" "}
+          {totalCount === 1 ? strings.play : strings.playsLabel}
+        </span>
+      </div>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}>{strings.title}</th>
+            <th className={styles.th}>{strings.station}</th>
+            <th className={styles.th}>{strings.timePlayed}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plays.map(({ title, time_played, station, id }) => (
+            <tr key={id}>
+              <td className={styles.td}>{title}</td>
+              <td className={styles.td}>
+                <StationBadge station={station} />
+              </td>
+              <td className={styles.tdTime}>{formatDate(time_played)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className={styles.mobileList}>
+        {plays.map(({ title, time_played, station, id }) => (
+          <div key={id} className={styles.mobileCard}>
+            <div className={styles.mobileTitle}>{title}</div>
+            <div className={styles.mobileMeta}>
+              <StationBadge station={station} />
+              <span>{formatDate(time_played)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        basePath={`/artists/${params.slug}`}
+      />
     </div>
   );
 }

--- a/packages/web-ui/app/artists/[slug]/page.tsx
+++ b/packages/web-ui/app/artists/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import { getArtistPlays, getArtistPlayCount } from "@/utils/database";
 import format from "date-fns/format";
 import { heading } from "@/styles/typography.css";
@@ -32,6 +33,10 @@ export default async function ArtistPage({
     getArtistPlays(artistName, offset, PAGE_SIZE),
     getArtistPlayCount(artistName),
   ]);
+
+  if (plays === null || totalCount === null) {
+    notFound();
+  }
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 

--- a/packages/web-ui/app/artists/components/Pagination.tsx
+++ b/packages/web-ui/app/artists/components/Pagination.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import * as styles from "@/styles/pagination.css";
+import { strings } from "@/utils/strings";
+
+type Props = {
+  currentPage: number;
+  totalPages: number;
+  basePath: string;
+  extraParams?: Record<string, string>;
+};
+
+function buildHref(
+  basePath: string,
+  page: number,
+  extraParams?: Record<string, string>
+) {
+  const params = new URLSearchParams();
+  if (page > 0) params.set("page", String(page));
+  if (extraParams) {
+    for (const [k, v] of Object.entries(extraParams)) {
+      if (v) params.set(k, v);
+    }
+  }
+  const qs = params.toString();
+  return qs ? `${basePath}?${qs}` : basePath;
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  basePath,
+  extraParams,
+}: Props) {
+  if (totalPages <= 1) return null;
+
+  const hasPrev = currentPage > 0;
+  const hasNext = currentPage < totalPages - 1;
+
+  return (
+    <div className={styles.pagination}>
+      {hasPrev ? (
+        <Link
+          href={buildHref(basePath, currentPage - 1, extraParams)}
+          className={styles.pageLink}
+        >
+          {strings.previousPage}
+        </Link>
+      ) : (
+        <span className={styles.pageLinkDisabled}>{strings.previousPage}</span>
+      )}
+      <span className={styles.pageInfo}>
+        {strings.pageOf(currentPage + 1, totalPages)}
+      </span>
+      {hasNext ? (
+        <Link
+          href={buildHref(basePath, currentPage + 1, extraParams)}
+          className={styles.pageLink}
+        >
+          {strings.nextPage}
+        </Link>
+      ) : (
+        <span className={styles.pageLinkDisabled}>{strings.nextPage}</span>
+      )}
+    </div>
+  );
+}

--- a/packages/web-ui/app/artists/loading.tsx
+++ b/packages/web-ui/app/artists/loading.tsx
@@ -1,0 +1,17 @@
+import * as skeleton from "@/styles/loading.css";
+
+export default function Loading() {
+  return (
+    <div>
+      <div className={skeleton.skeletonHeading} />
+      <div className={skeleton.skeletonSearch} />
+      {Array.from({ length: 12 }, (_, i) => (
+        <div
+          key={i}
+          className={skeleton.skeletonRow}
+          style={{ width: `${60 + Math.random() * 30}%` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/web-ui/app/artists/page.tsx
+++ b/packages/web-ui/app/artists/page.tsx
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import Link from "next/link";
-import { getArtists } from "@/utils/database";
-import { body, link } from "@/styles/typography.css";
+import { searchArtists, getArtistCount } from "@/utils/database";
+import { heading } from "@/styles/typography.css";
+import * as styles from "@/styles/artists.css";
+import { strings } from "@/utils/strings";
+import { Pagination } from "./components/Pagination";
 
 const PAGE_SIZE = 30;
 
@@ -9,56 +12,62 @@ type Props = {
   searchParams?: unknown;
 };
 
-export default async function Artist(props: Props) {
-  const paramsSchema = z
-    .object({
-      page: z.string().regex(/^\d+$/).transform(Number).optional(),
-    })
-    .optional();
+const paramsSchema = z
+  .object({
+    page: z.string().regex(/^\d+$/).transform(Number).optional(),
+    q: z.string().optional(),
+  })
+  .optional();
 
-  const getOffset = () => {
-    const parsedSearchParams = paramsSchema.safeParse(props.searchParams);
+export default async function ArtistsPage(props: Props) {
+  const parsed = paramsSchema.safeParse(props.searchParams);
+  const page = parsed.success ? parsed.data?.page ?? 0 : 0;
+  const query = parsed.success ? parsed.data?.q : undefined;
+  const offset = page * PAGE_SIZE;
 
-    if (!parsedSearchParams.success) {
-      return 0;
-    }
+  const [artists, totalCount] = await Promise.all([
+    searchArtists(query, offset, PAGE_SIZE),
+    getArtistCount(query),
+  ]);
 
-    return (parsedSearchParams.data?.page ?? 0) * PAGE_SIZE;
-  };
-
-  const data = await getArtists(getOffset(), PAGE_SIZE);
-
-  const schema = z.array(
-    z.object({
-      id: z.number(),
-      name: z.string(),
-    })
-  );
-
-  const parsed = schema.safeParse(data);
-
-  if (!parsed.success) {
-    return (
-      <div>
-        <h1>Error</h1>
-        <p>{parsed.error.message}</p>
-      </div>
-    );
-  }
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "1fr",
-      }}
-    >
-      <div className={body}>Artist name</div>
-      {parsed.data.map(({ id, name }) => (
-        <Link href={`artists/${name}`} key={id}>
-          <div className={[body, link].join(" ")}>{name}</div>
-        </Link>
-      ))}
+    <div>
+      <h1 className={heading}>{strings.artists}</h1>
+
+      <form action="/artists" method="GET" className={styles.searchForm}>
+        <input
+          type="search"
+          name="q"
+          placeholder={strings.searchArtistsPlaceholder}
+          defaultValue={query ?? ""}
+          className={styles.searchInput}
+        />
+      </form>
+
+      {artists && artists.length > 0 ? (
+        <div className={styles.artistList}>
+          {artists.map(({ id, name }) => (
+            <Link href={`/artists/${name}`} key={id} className={styles.artistRow}>
+              {name}
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.emptyState}>
+          {query
+            ? strings.noArtistsFoundMatching(query)
+            : strings.noArtistsFound}
+        </div>
+      )}
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        basePath="/artists"
+        extraParams={query ? { q: query } : undefined}
+      />
     </div>
   );
 }

--- a/packages/web-ui/app/components/Header.tsx
+++ b/packages/web-ui/app/components/Header.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import * as styles from "@/styles/header.css";
+import { strings } from "@/utils/strings";
+
+export function Header() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerInner}>
+        <Link href="/" className={styles.siteName}>
+          {strings.siteName}
+        </Link>
+        <nav className={styles.nav}>
+          <Link href="/artists" className={styles.navLink}>
+            {strings.navArtists}
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/packages/web-ui/app/components/StationBadge.tsx
+++ b/packages/web-ui/app/components/StationBadge.tsx
@@ -1,0 +1,8 @@
+import { badge } from "@/styles/station-badge.css";
+
+const knownStations = new Set(Object.keys(badge).filter((k) => k !== "default"));
+
+export function StationBadge({ station }: { station: string }) {
+  const key = knownStations.has(station) ? station : "default";
+  return <span className={badge[key]}>{station}</span>;
+}

--- a/packages/web-ui/app/globals.css
+++ b/packages/web-ui/app/globals.css
@@ -1,82 +1,15 @@
-:root {
-  --max-width: 1100px;
-  --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-    'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-    'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
-
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-
-  --primary-glow: conic-gradient(
-    from 180deg at 50% 50%,
-    #16abff33 0deg,
-    #0885ff33 55deg,
-    #54d6ff33 120deg,
-    #0071ff33 160deg,
-    transparent 360deg
-  );
-  --secondary-glow: radial-gradient(
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0)
-  );
-
-  --tile-start-rgb: 239, 245, 249;
-  --tile-end-rgb: 228, 232, 233;
-  --tile-border: conic-gradient(
-    #00000080,
-    #00000040,
-    #00000030,
-    #00000020,
-    #00000010,
-    #00000010,
-    #00000080
-  );
-
-  --callout-rgb: 238, 240, 241;
-  --callout-border-rgb: 172, 175, 176;
-  --card-rgb: 180, 185, 188;
-  --card-border-rgb: 131, 134, 135;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
-
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
-
-    --callout-rgb: 20, 20, 20;
-    --callout-border-rgb: 108, 108, 108;
-    --card-rgb: 100, 100, 100;
-    --card-border-rgb: 200, 200, 200;
-  }
-}
-
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
-  padding: 0;
   margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  tab-size: 4;
 }
 
 html,
@@ -86,13 +19,28 @@ body {
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  background-color: var(--bgPage);
+  color: var(--textPrimary);
+  font-family: var(--font-body);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
 }
 
 a {
@@ -100,8 +48,21 @@ a {
   text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
 }

--- a/packages/web-ui/app/layout.tsx
+++ b/packages/web-ui/app/layout.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-// import "./globals.css";
+import "./globals.css";
 import * as layout from "@/styles/layout.css";
-
-const inter = Inter({ subsets: ["latin"] });
+import { Header } from "./components/Header";
+import { strings } from "@/utils/strings";
 
 export const metadata: Metadata = {
-  title: "Radio Scraper",
-  description: "Faroese radio songs",
+  title: strings.siteName,
+  description: strings.siteDescription,
 };
 
 export default function RootLayout({
@@ -18,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={layout.root}>
+        <Header />
         <main className={layout.content}>{children}</main>
       </body>
     </html>

--- a/packages/web-ui/app/not-found.tsx
+++ b/packages/web-ui/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import * as styles from "@/styles/not-found.css";
+import { strings } from "@/utils/strings";
+
+export default function NotFound() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.code}>{strings.notFoundCode}</div>
+      <p className={styles.message}>{strings.notFoundMessage}</p>
+      <Link href="/" className={styles.homeLink}>
+        {strings.goBackHome}
+      </Link>
+    </div>
+  );
+}

--- a/packages/web-ui/app/page.tsx
+++ b/packages/web-ui/app/page.tsx
@@ -1,9 +1,77 @@
+import Link from "next/link";
+import { getStats, getRecentPlays } from "@/utils/database";
 import { heading } from "@/styles/typography.css";
+import * as styles from "@/styles/home.css";
+import { StationBadge } from "./components/StationBadge";
+import { link } from "@/styles/typography.css";
+import { strings } from "@/utils/strings";
+import format from "date-fns/format";
 
-export default function Home() {
+function formatNumber(n: number) {
+  return n.toLocaleString("en-US");
+}
+
+export default async function Home() {
+  const [stats, recentPlays] = await Promise.all([
+    getStats(),
+    getRecentPlays(10),
+  ]);
+
   return (
     <div>
-      <h1 className={heading}>Radio scraper.</h1>
+      <div className={styles.hero}>
+        <h1 className={heading}>{strings.siteName}</h1>
+        <p className={styles.subtitle}>{strings.homeSubtitle}</p>
+      </div>
+
+      <div className={styles.statsGrid}>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {formatNumber(stats.artistCount)}
+          </div>
+          <div className={styles.statLabel}>{strings.artists}</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {formatNumber(stats.songCount)}
+          </div>
+          <div className={styles.statLabel}>{strings.songs}</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {formatNumber(stats.playCount)}
+          </div>
+          <div className={styles.statLabel}>{strings.plays}</div>
+        </div>
+      </div>
+
+      <h2 className={styles.sectionHeading}>{strings.recentPlays}</h2>
+      <div className={styles.recentList}>
+        {recentPlays.map((play) => (
+          <div key={play.id} className={styles.recentItem}>
+            <div className={styles.recentInfo}>
+              <span className={styles.recentTitle}>{play.title}</span>
+              <span className={styles.recentMeta}>
+                <Link href={`/artists/${play.artist}`} className={link}>
+                  {play.artist}
+                </Link>
+              </span>
+            </div>
+            <div className={styles.recentRight}>
+              <StationBadge station={play.station} />
+              <span className={styles.recentTime}>
+                {format(new Date(play.time_played), "MMM d, HH:mm")}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Link href="/artists" className={styles.ctaLink}>
+        {strings.browseAllArtists}
+      </Link>
     </div>
   );
 }
+
+export const dynamic = "force-dynamic";

--- a/packages/web-ui/styles/artist-detail.css.ts
+++ b/packages/web-ui/styles/artist-detail.css.ts
@@ -1,0 +1,104 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const backLink = style({
+  display: "inline-flex",
+  alignItems: "center",
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  textDecoration: "none",
+  marginBottom: vars.space["6"],
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accent,
+  },
+});
+
+export const headerRow = style({
+  display: "flex",
+  alignItems: "baseline",
+  gap: vars.space["3"],
+  marginBottom: vars.space["6"],
+  flexWrap: "wrap",
+});
+
+export const playCount = style({
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});
+
+export const table = style({
+  width: "100%",
+  borderCollapse: "collapse",
+  "@media": {
+    "(max-width: 639px)": {
+      display: "none",
+    },
+  },
+});
+
+export const th = style({
+  textAlign: "left",
+  padding: `${vars.space["2"]} ${vars.space["3"]}`,
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textSecondary,
+  borderBottom: `2px solid ${vars.color.border}`,
+});
+
+export const td = style({
+  padding: `${vars.space["3"]}`,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.textPrimary,
+  borderBottom: `1px solid ${vars.color.border}`,
+  verticalAlign: "middle",
+});
+
+export const tdTime = style([
+  td,
+  {
+    fontSize: vars.fontSize.sm,
+    color: vars.color.textSecondary,
+    whiteSpace: "nowrap",
+  },
+]);
+
+export const mobileList = style({
+  display: "none",
+  flexDirection: "column",
+  gap: vars.space["3"],
+  "@media": {
+    "(max-width: 639px)": {
+      display: "flex",
+    },
+  },
+});
+
+export const mobileCard = style({
+  backgroundColor: vars.color.bgSurface,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space["4"],
+});
+
+export const mobileTitle = style({
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space["1"],
+});
+
+export const mobileMeta = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: vars.space["2"],
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});

--- a/packages/web-ui/styles/artists.css.ts
+++ b/packages/web-ui/styles/artists.css.ts
@@ -1,0 +1,52 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const searchForm = style({
+  marginBottom: vars.space["6"],
+});
+
+export const searchInput = style({
+  width: "100%",
+  padding: `${vars.space["3"]} ${vars.space["4"]}`,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.bgSurface,
+  color: vars.color.textPrimary,
+  outline: "none",
+  transition: "border-color 150ms ease",
+  "::placeholder": {
+    color: vars.color.textMuted,
+  },
+  ":focus": {
+    borderColor: vars.color.accent,
+  },
+});
+
+export const artistList = style({
+  display: "flex",
+  flexDirection: "column",
+});
+
+export const artistRow = style({
+  display: "block",
+  padding: `${vars.space["3"]} ${vars.space["4"]}`,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.textPrimary,
+  textDecoration: "none",
+  borderRadius: vars.radius.sm,
+  transition: "background-color 150ms ease",
+  ":hover": {
+    backgroundColor: vars.color.bgHover,
+  },
+});
+
+export const emptyState = style({
+  textAlign: "center",
+  padding: `${vars.space["12"]} 0`,
+  color: vars.color.textSecondary,
+  fontFamily: vars.font.body,
+  fontSize: vars.fontSize.base,
+});

--- a/packages/web-ui/styles/header.css.ts
+++ b/packages/web-ui/styles/header.css.ts
@@ -1,0 +1,53 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const header = style({
+  position: "sticky",
+  top: 0,
+  zIndex: 10,
+  backgroundColor: vars.color.bgSurface,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const headerInner = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  maxWidth: "860px",
+  marginLeft: "auto",
+  marginRight: "auto",
+  padding: `${vars.space["3"]} ${vars.space["4"]}`,
+  "@media": {
+    "(min-width: 640px)": {
+      padding: `${vars.space["3"]} ${vars.space["6"]}`,
+    },
+  },
+});
+
+export const siteName = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  textDecoration: "none",
+  ":hover": {
+    color: vars.color.accent,
+  },
+  transition: "color 150ms ease",
+});
+
+export const nav = style({
+  display: "flex",
+  gap: vars.space["4"],
+});
+
+export const navLink = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  textDecoration: "none",
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accent,
+  },
+});

--- a/packages/web-ui/styles/home.css.ts
+++ b/packages/web-ui/styles/home.css.ts
@@ -1,0 +1,127 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const hero = style({
+  marginBottom: vars.space["12"],
+});
+
+export const subtitle = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  marginTop: vars.space["2"],
+});
+
+export const statsGrid = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  gap: vars.space["4"],
+  marginBottom: vars.space["12"],
+});
+
+export const statCard = style({
+  backgroundColor: vars.color.bgSurface,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space["6"],
+  textAlign: "center",
+});
+
+export const statValue = style({
+  fontSize: vars.fontSize["3xl"],
+  fontFamily: vars.font.body,
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  lineHeight: 1,
+});
+
+export const statLabel = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  marginTop: vars.space["1"],
+});
+
+export const sectionHeading = style({
+  fontSize: vars.fontSize.xl,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space["4"],
+});
+
+export const recentList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: 0,
+  marginBottom: vars.space["8"],
+});
+
+export const recentItem = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: vars.space["3"],
+  padding: `${vars.space["3"]} 0`,
+  borderBottom: `1px solid ${vars.color.border}`,
+  selectors: {
+    "&:last-child": {
+      borderBottom: "none",
+    },
+  },
+});
+
+export const recentInfo = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space["1"],
+  minWidth: 0,
+  flex: 1,
+});
+
+export const recentTitle = style({
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.textPrimary,
+  fontWeight: 500,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+export const recentMeta = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space["2"],
+  fontSize: vars.fontSize.sm,
+  color: vars.color.textSecondary,
+  fontFamily: vars.font.body,
+});
+
+export const recentRight = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space["3"],
+  flexShrink: 0,
+});
+
+export const recentTime = style({
+  fontSize: vars.fontSize.xs,
+  fontFamily: vars.font.body,
+  color: vars.color.textMuted,
+  whiteSpace: "nowrap",
+});
+
+export const ctaLink = style({
+  display: "inline-flex",
+  alignItems: "center",
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.accent,
+  textDecoration: "none",
+  fontWeight: 500,
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accentHover,
+  },
+});

--- a/packages/web-ui/styles/layout.css.ts
+++ b/packages/web-ui/styles/layout.css.ts
@@ -1,12 +1,21 @@
 import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
 
 export const root = style({
   display: "flex",
-  justifyContent: "center",
+  flexDirection: "column",
+  minHeight: "100vh",
 });
 
 export const content = style({
   width: "100%",
-  maxWidth: "800px",
-  padding: "0 16px",
+  maxWidth: "860px",
+  marginLeft: "auto",
+  marginRight: "auto",
+  padding: `${vars.space["8"]} ${vars.space["4"]}`,
+  "@media": {
+    "(min-width: 640px)": {
+      padding: `${vars.space["8"]} ${vars.space["6"]}`,
+    },
+  },
 });

--- a/packages/web-ui/styles/loading.css.ts
+++ b/packages/web-ui/styles/loading.css.ts
@@ -1,0 +1,70 @@
+import { style, keyframes } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+const pulse = keyframes({
+  "0%, 100%": { opacity: 1 },
+  "50%": { opacity: 0.4 },
+});
+
+const skeleton = style({
+  backgroundColor: vars.color.border,
+  borderRadius: vars.radius.sm,
+  animation: `${pulse} 1.5s ease-in-out infinite`,
+});
+
+export const skeletonHeading = style([
+  skeleton,
+  { height: "2rem", width: "200px", marginBottom: vars.space["6"] },
+]);
+
+export const skeletonSearch = style([
+  skeleton,
+  {
+    height: "44px",
+    width: "100%",
+    borderRadius: vars.radius.md,
+    marginBottom: vars.space["6"],
+  },
+]);
+
+export const skeletonRow = style([
+  skeleton,
+  {
+    height: "1.25rem",
+    marginBottom: vars.space["3"],
+    borderRadius: vars.radius.sm,
+  },
+]);
+
+export const skeletonStatGrid = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  gap: vars.space["4"],
+  marginBottom: vars.space["12"],
+});
+
+export const skeletonStatCard = style([
+  skeleton,
+  {
+    height: "96px",
+    borderRadius: vars.radius.md,
+  },
+]);
+
+export const skeletonBack = style([
+  skeleton,
+  { height: "1rem", width: "100px", marginBottom: vars.space["6"] },
+]);
+
+export const skeletonTableRow = style({
+  display: "grid",
+  gridTemplateColumns: "2fr 1fr 1.5fr",
+  gap: vars.space["3"],
+  padding: `${vars.space["3"]} 0`,
+  borderBottom: `1px solid ${vars.color.border}`,
+});
+
+export const skeletonCell = style([
+  skeleton,
+  { height: "1rem" },
+]);

--- a/packages/web-ui/styles/not-found.css.ts
+++ b/packages/web-ui/styles/not-found.css.ts
@@ -1,0 +1,37 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const container = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  textAlign: "center",
+  padding: `${vars.space["16"]} 0`,
+});
+
+export const code = style({
+  fontSize: vars.fontSize["3xl"],
+  fontFamily: vars.font.body,
+  fontWeight: 700,
+  color: vars.color.textMuted,
+  marginBottom: vars.space["2"],
+});
+
+export const message = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  marginBottom: vars.space["8"],
+});
+
+export const homeLink = style({
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.accent,
+  textDecoration: "none",
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accentHover,
+  },
+});

--- a/packages/web-ui/styles/pagination.css.ts
+++ b/packages/web-ui/styles/pagination.css.ts
@@ -1,0 +1,42 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+export const pagination = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: vars.space["4"],
+  padding: `${vars.space["6"]} 0`,
+});
+
+export const pageInfo = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});
+
+export const pageLink = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.accent,
+  textDecoration: "none",
+  padding: `${vars.space["2"]} ${vars.space["3"]}`,
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  transition: "all 150ms ease",
+  ":hover": {
+    backgroundColor: vars.color.accentLight,
+    borderColor: vars.color.accent,
+  },
+});
+
+export const pageLinkDisabled = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textMuted,
+  padding: `${vars.space["2"]} ${vars.space["3"]}`,
+  borderRadius: vars.radius.sm,
+  border: `1px solid ${vars.color.border}`,
+  cursor: "default",
+  opacity: 0.5,
+});

--- a/packages/web-ui/styles/station-badge.css.ts
+++ b/packages/web-ui/styles/station-badge.css.ts
@@ -1,0 +1,27 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+import { vars } from "./theme.css";
+
+const badgeBase = style({
+  display: "inline-block",
+  fontSize: vars.fontSize.xs,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  padding: `${vars.space["1"]} ${vars.space["2"]}`,
+  borderRadius: vars.radius.sm,
+  textTransform: "uppercase",
+  letterSpacing: "0.03em",
+  lineHeight: 1,
+  whiteSpace: "nowrap",
+});
+
+const stationColors: Record<string, { bg: string; color: string }> = {
+  kvf: { bg: "#e8f0fe", color: "#1a56db" },
+  ras2: { bg: "#fef3e2", color: "#b45309" },
+  lindin: { bg: "#e6f9ed", color: "#16803c" },
+  default: { bg: vars.color.bgHover, color: vars.color.textSecondary },
+};
+
+export const badge = styleVariants(stationColors, (colors) => [
+  badgeBase,
+  { backgroundColor: colors.bg, color: colors.color },
+]);

--- a/packages/web-ui/styles/theme.css.ts
+++ b/packages/web-ui/styles/theme.css.ts
@@ -1,0 +1,44 @@
+import { createGlobalTheme } from "@vanilla-extract/css";
+
+export const vars = createGlobalTheme(":root", {
+  color: {
+    textPrimary: "#1a1a2e",
+    textSecondary: "#555770",
+    textMuted: "#8a8da0",
+    bgPage: "#f8f9fb",
+    bgSurface: "#ffffff",
+    bgHover: "#f0f1f5",
+    border: "#e2e4ea",
+    accent: "#4a6fa5",
+    accentHover: "#3d5d8a",
+    accentLight: "#eef2f8",
+  },
+  space: {
+    "1": "4px",
+    "2": "8px",
+    "3": "12px",
+    "4": "16px",
+    "6": "24px",
+    "8": "32px",
+    "12": "48px",
+    "16": "64px",
+  },
+  font: {
+    body: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+    mono: "ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', 'Roboto Mono', monospace",
+  },
+  fontSize: {
+    xs: "0.75rem",
+    sm: "0.875rem",
+    base: "1rem",
+    lg: "1.125rem",
+    xl: "1.25rem",
+    "2xl": "1.5rem",
+    "3xl": "2rem",
+  },
+  radius: {
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+  },
+});

--- a/packages/web-ui/styles/typography.css.ts
+++ b/packages/web-ui/styles/typography.css.ts
@@ -1,127 +1,47 @@
 import { style } from "@vanilla-extract/css";
-
-const FONT =
-  "ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', 'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro', 'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace";
+import { vars } from "./theme.css";
 
 export const heading = style({
-  fontSize: "24px",
-  fontFamily: FONT,
+  fontSize: vars.fontSize["3xl"],
+  fontFamily: vars.font.body,
+  fontWeight: 700,
+  color: vars.color.textPrimary,
+  lineHeight: 1.2,
+});
+
+export const headingLg = style({
+  fontSize: vars.fontSize["2xl"],
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  lineHeight: 1.3,
 });
 
 export const body = style({
-  fontSize: "16px",
-  fontFamily: FONT,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  color: vars.color.textPrimary,
+  lineHeight: 1.5,
+});
+
+export const bodySmall = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  lineHeight: 1.5,
+});
+
+export const mono = style({
+  fontFamily: vars.font.mono,
+  fontSize: vars.fontSize.sm,
 });
 
 export const link = style({
-  color: "inherit",
+  color: vars.color.accent,
   textDecoration: "none",
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accentHover,
+    textDecoration: "underline",
+  },
 });
-
-// :root {
-//   --max-width: 1100px;
-//   --border-radius: 12px;
-//   --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono',
-//     'Roboto Mono', 'Oxygen Mono', 'Ubuntu Monospace', 'Source Code Pro',
-//     'Fira Mono', 'Droid Sans Mono', 'Courier New', monospace;
-
-//   --foreground-rgb: 0, 0, 0;
-//   --background-start-rgb: 214, 219, 220;
-//   --background-end-rgb: 255, 255, 255;
-
-//   --primary-glow: conic-gradient(
-//     from 180deg at 50% 50%,
-//     #16abff33 0deg,
-//     #0885ff33 55deg,
-//     #54d6ff33 120deg,
-//     #0071ff33 160deg,
-//     transparent 360deg
-//   );
-//   --secondary-glow: radial-gradient(
-//     rgba(255, 255, 255, 1),
-//     rgba(255, 255, 255, 0)
-//   );
-
-//   --tile-start-rgb: 239, 245, 249;
-//   --tile-end-rgb: 228, 232, 233;
-//   --tile-border: conic-gradient(
-//     #00000080,
-//     #00000040,
-//     #00000030,
-//     #00000020,
-//     #00000010,
-//     #00000010,
-//     #00000080
-//   );
-
-//   --callout-rgb: 238, 240, 241;
-//   --callout-border-rgb: 172, 175, 176;
-//   --card-rgb: 180, 185, 188;
-//   --card-border-rgb: 131, 134, 135;
-// }
-
-// @media (prefers-color-scheme: dark) {
-//   :root {
-//     --foreground-rgb: 255, 255, 255;
-//     --background-start-rgb: 0, 0, 0;
-//     --background-end-rgb: 0, 0, 0;
-
-//     --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-//     --secondary-glow: linear-gradient(
-//       to bottom right,
-//       rgba(1, 65, 255, 0),
-//       rgba(1, 65, 255, 0),
-//       rgba(1, 65, 255, 0.3)
-//     );
-
-//     --tile-start-rgb: 2, 13, 46;
-//     --tile-end-rgb: 2, 5, 19;
-//     --tile-border: conic-gradient(
-//       #ffffff80,
-//       #ffffff40,
-//       #ffffff30,
-//       #ffffff20,
-//       #ffffff10,
-//       #ffffff10,
-//       #ffffff80
-//     );
-
-//     --callout-rgb: 20, 20, 20;
-//     --callout-border-rgb: 108, 108, 108;
-//     --card-rgb: 100, 100, 100;
-//     --card-border-rgb: 200, 200, 200;
-//   }
-// }
-
-// * {
-//   box-sizing: border-box;
-//   padding: 0;
-//   margin: 0;
-// }
-
-// html,
-// body {
-//   max-width: 100vw;
-//   overflow-x: hidden;
-// }
-
-// body {
-//   color: rgb(var(--foreground-rgb));
-//   background: linear-gradient(
-//       to bottom,
-//       transparent,
-//       rgb(var(--background-end-rgb))
-//     )
-//     rgb(var(--background-start-rgb));
-// }
-
-// a {
-//   color: inherit;
-//   text-decoration: none;
-// }
-
-// @media (prefers-color-scheme: dark) {
-//   html {
-//     color-scheme: dark;
-//   }
-// }

--- a/packages/web-ui/utils/database.ts
+++ b/packages/web-ui/utils/database.ts
@@ -17,19 +17,93 @@ function getSupabase() {
   return _supabase;
 }
 
-export async function getArtists(offset: number, limit: number) {
+export async function getStats() {
+  const [artists, songs, plays] = await Promise.all([
+    getSupabase()
+      .from("artists")
+      .select("*", { count: "exact", head: true }),
+    getSupabase()
+      .from("songs")
+      .select("*", { count: "exact", head: true }),
+    getSupabase()
+      .from("plays")
+      .select("*", { count: "exact", head: true })
+      .eq("is_deleted", false)
+      .eq("is_likely_not_music", false),
+  ]);
+
+  return {
+    artistCount: artists.count ?? 0,
+    songCount: songs.count ?? 0,
+    playCount: plays.count ?? 0,
+  };
+}
+
+export async function getRecentPlays(limit: number) {
   const { data, error } = await getSupabase()
+    .from("plays")
+    .select(
+      `
+      id,
+      time_played,
+      songs!inner (
+        title,
+        artists!inner ( name )
+      ),
+      stations!inner ( slug )
+    `
+    )
+    .eq("is_deleted", false)
+    .eq("is_likely_not_music", false)
+    .order("time_played", { ascending: false })
+    .limit(limit);
+
+  if (error) throw error;
+
+  return data.map((play: any) => ({
+    id: play.id,
+    artist: (play.songs as any).artists.name,
+    title: (play.songs as any).title,
+    time_played: play.time_played,
+    station: (play.stations as any).slug,
+  }));
+}
+
+export async function getArtistCount(query?: string) {
+  let q = getSupabase()
+    .from("artists")
+    .select("*", { count: "exact", head: true });
+
+  if (query) {
+    q = q.ilike("name", `%${query}%`);
+  }
+
+  const { count, error } = await q;
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function searchArtists(
+  query: string | undefined,
+  offset: number,
+  limit: number
+) {
+  let q = getSupabase()
     .from("artists")
     .select("id, name")
     .order("name", { ascending: true })
     .range(offset, offset + limit - 1);
 
+  if (query) {
+    q = q.ilike("name", `%${query}%`);
+  }
+
+  const { data, error } = await q;
   if (error) throw error;
   return data;
 }
 
-export async function getArtistPlays(artistName: string) {
-  // First find the artist by name (case-insensitive)
+async function findArtistId(artistName: string) {
   const { data: artist, error: artistError } = await getSupabase()
     .from("artists")
     .select("id")
@@ -37,16 +111,36 @@ export async function getArtistPlays(artistName: string) {
     .single();
 
   if (artistError) throw artistError;
+  return artist.id;
+}
 
-  // Get all plays for this artist's songs, joining through songs -> plays -> stations
+export async function getArtistPlayCount(artistName: string) {
+  const artistId = await findArtistId(artistName);
+
+  const { count, error } = await getSupabase()
+    .from("plays")
+    .select("*, songs!inner(*)", { count: "exact", head: true })
+    .eq("songs.artist_id", artistId)
+    .eq("is_deleted", false)
+    .eq("is_likely_not_music", false);
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function getArtistPlays(
+  artistName: string,
+  offset: number = 0,
+  limit: number = 50
+) {
+  const artistId = await findArtistId(artistName);
+
   const { data, error } = await getSupabase()
     .from("plays")
     .select(
       `
       id,
       time_played,
-      is_deleted,
-      is_likely_not_music,
       songs!inner (
         title,
         artist_id,
@@ -55,10 +149,11 @@ export async function getArtistPlays(artistName: string) {
       stations!inner ( slug )
     `
     )
-    .eq("songs.artist_id", artist.id)
+    .eq("songs.artist_id", artistId)
     .eq("is_deleted", false)
     .eq("is_likely_not_music", false)
-    .order("time_played", { ascending: false });
+    .order("time_played", { ascending: false })
+    .range(offset, offset + limit - 1);
 
   if (error) throw error;
 

--- a/packages/web-ui/utils/database.ts
+++ b/packages/web-ui/utils/database.ts
@@ -103,19 +103,23 @@ export async function searchArtists(
   return data;
 }
 
-async function findArtistId(artistName: string) {
+async function findArtistId(artistName: string): Promise<number | null> {
   const { data: artist, error: artistError } = await getSupabase()
     .from("artists")
     .select("id")
-    .ilike("name", artistName)
+    .eq("name", artistName)
     .single();
 
-  if (artistError) throw artistError;
+  if (artistError) {
+    if (artistError.code === "PGRST116") return null;
+    throw artistError;
+  }
   return artist.id;
 }
 
 export async function getArtistPlayCount(artistName: string) {
   const artistId = await findArtistId(artistName);
+  if (artistId === null) return null;
 
   const { count, error } = await getSupabase()
     .from("plays")
@@ -134,6 +138,7 @@ export async function getArtistPlays(
   limit: number = 50
 ) {
   const artistId = await findArtistId(artistName);
+  if (artistId === null) return null;
 
   const { data, error } = await getSupabase()
     .from("plays")

--- a/packages/web-ui/utils/strings.ts
+++ b/packages/web-ui/utils/strings.ts
@@ -1,0 +1,30 @@
+export const strings = {
+  siteName: "Faroese Radio",
+  siteDescription:
+    "A historical record of songs played on Faroese radio stations",
+  homeSubtitle:
+    "A historical record of every song played on Faroese radio stations.",
+  browseAllArtists: "Browse all artists →",
+  recentPlays: "Recent plays",
+  artists: "Artists",
+  songs: "Songs",
+  plays: "Plays",
+  searchArtistsPlaceholder: "Search artists...",
+  noArtistsFound: "No artists found",
+  noArtistsFoundMatching: (query: string) =>
+    `No artists found matching "${query}"`,
+  allArtists: "← All artists",
+  play: "play",
+  playsLabel: "plays",
+  title: "Title",
+  station: "Station",
+  timePlayed: "Time played",
+  previousPage: "← Previous",
+  nextPage: "Next →",
+  pageOf: (current: number, total: number) =>
+    `Page ${current} of ${total}`,
+  notFoundCode: "404",
+  notFoundMessage: "This page could not be found.",
+  goBackHome: "Go back home",
+  navArtists: "Artists",
+} as const;


### PR DESCRIPTION
## Summary
- Add Vanilla Extract theme system with design tokens (colors, spacing, fonts, radii)
- Add sticky header with site name and artist navigation
- Redesign home page with stats cards (artists/songs/plays) and recent plays list
- Add artist search (native form GET) and pagination to artists list
- Redesign artist detail page with responsive table/card layout and station badges
- Add loading skeletons, custom 404 page, and focus-visible keyboard styles
- Extract all user-facing strings to `utils/strings.ts` for future i18n

## Test plan
- [ ] `pnpm --filter web-ui run build` succeeds
- [ ] Home page shows stats and recent plays
- [ ] `/artists` — search works, pagination works
- [ ] `/artists/[name]` — plays display with station badges, pagination
- [ ] Mobile layout works (responsive mode)
- [ ] Keyboard navigation has visible focus outlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)