### PR TITLE
Improve charts loading UX with Suspense and shimmer

### DIFF
--- a/packages/web-ui/app/charts/ChartResults.tsx
+++ b/packages/web-ui/app/charts/ChartResults.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import {
+  getTopArtistsForMonth,
+  getTopSongsForMonth,
+} from "@/utils/database";
+import * as styles from "@/styles/charts.css";
+import { strings } from "@/utils/strings";
+
+export async function ChartResults({
+  year,
+  month,
+  selectedSlugs,
+}: {
+  year: number;
+  month: number;
+  selectedSlugs?: string[];
+}) {
+  const [topArtists, topSongs] = await Promise.all([
+    getTopArtistsForMonth(year, month, 10, selectedSlugs),
+    getTopSongsForMonth(year, month, 10, selectedSlugs),
+  ]);
+
+  if (topArtists.length === 0 && topSongs.length === 0) {
+    return (
+      <div className={styles.emptyState}>{strings.noDataForMonth}</div>
+    );
+  }
+
+  return (
+    <div className={styles.listsGrid}>
+      <div className={styles.listSection}>
+        <h2 className={styles.listHeading}>{strings.topArtists}</h2>
+        <div className={styles.rankedList}>
+          {topArtists.map((artist, i) => (
+            <div key={artist.name} className={styles.rankedItem}>
+              <span className={styles.rankNumber}>{i + 1}</span>
+              <div className={styles.rankInfo}>
+                <Link
+                  href={`/artists/${artist.name}`}
+                  className={styles.rankName}
+                >
+                  {artist.name}
+                </Link>
+              </div>
+              <span className={styles.rankCount}>
+                {artist.playCount} {strings.playsLabel}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.listSection}>
+        <h2 className={styles.listHeading}>{strings.topSongs}</h2>
+        <div className={styles.rankedList}>
+          {topSongs.map((song, i) => (
+            <div
+              key={`${song.title}-${song.artist}`}
+              className={styles.rankedItem}
+            >
+              <span className={styles.rankNumber}>{i + 1}</span>
+              <div className={styles.rankInfo}>
+                <Link
+                  href={`/artists/${song.artist}/${encodeURIComponent(song.title)}`}
+                  className={styles.rankName}
+                >
+                  {song.title}
+                </Link>
+                <div className={styles.rankArtist}>
+                  <Link
+                    href={`/artists/${song.artist}`}
+                    style={{
+                      color: "inherit",
+                      textDecoration: "none",
+                    }}
+                  >
+                    {song.artist}
+                  </Link>
+                </div>
+              </div>
+              <span className={styles.rankCount}>
+                {song.playCount} {strings.playsLabel}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web-ui/app/charts/ChartResultsSkeleton.tsx
+++ b/packages/web-ui/app/charts/ChartResultsSkeleton.tsx
@@ -1,0 +1,45 @@
+import * as styles from "@/styles/charts.css";
+import * as skeleton from "@/styles/loading.css";
+import { strings } from "@/utils/strings";
+
+function SkeletonRankedList({ count }: { count: number }) {
+  return (
+    <div className={styles.rankedList}>
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i} className={styles.rankedItem}>
+          <span className={styles.rankNumber} style={{ opacity: 0.3 }}>
+            {i + 1}
+          </span>
+          <div className={styles.rankInfo}>
+            <div
+              className={skeleton.skeletonRow}
+              style={{
+                width: `${55 + Math.round(Math.sin(i * 2.3) * 25)}%`,
+                marginBottom: 0,
+              }}
+            />
+          </div>
+          <div
+            className={skeleton.skeletonCell}
+            style={{ width: "48px", flexShrink: 0 }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ChartResultsSkeleton() {
+  return (
+    <div className={styles.listsGrid}>
+      <div className={styles.listSection}>
+        <h2 className={styles.listHeading}>{strings.topArtists}</h2>
+        <SkeletonRankedList count={10} />
+      </div>
+      <div className={styles.listSection}>
+        <h2 className={styles.listHeading}>{strings.topSongs}</h2>
+        <SkeletonRankedList count={10} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web-ui/app/charts/page.tsx
+++ b/packages/web-ui/app/charts/page.tsx
@@ -1,14 +1,13 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { z } from "zod";
-import {
-  getTopArtistsForMonth,
-  getTopSongsForMonth,
-  getAllStationSlugs,
-} from "@/utils/database";
+import { getAllStationSlugs } from "@/utils/database";
 import { heading } from "@/styles/typography.css";
 import * as styles from "@/styles/charts.css";
 import { strings } from "@/utils/strings";
 import format from "date-fns/format";
+import { ChartResults } from "./ChartResults";
+import { ChartResultsSkeleton } from "./ChartResultsSkeleton";
 
 const paramsSchema = z
   .object({
@@ -79,11 +78,6 @@ export default async function ChartsPage({
     ? stationsParam.split(",").filter((s) => allSlugs.includes(s))
     : undefined;
 
-  const [topArtists, topSongs] = await Promise.all([
-    getTopArtistsForMonth(year, month, 10, selectedSlugs),
-    getTopSongsForMonth(year, month, 10, selectedSlugs),
-  ]);
-
   const prev = getPrevMonth(year, month);
   const next = getNextMonth(year, month);
   const lastCompleted = getLastCompletedMonth();
@@ -99,6 +93,8 @@ export default async function ChartsPage({
   const currentStationsParam = selectedSlugs
     ? selectedSlugs.join(",")
     : undefined;
+
+  const suspenseKey = `${year}-${month}-${currentStationsParam ?? "all"}`;
 
   return (
     <div>
@@ -163,69 +159,13 @@ export default async function ChartsPage({
         })}
       </div>
 
-      {topArtists.length === 0 && topSongs.length === 0 ? (
-        <div className={styles.emptyState}>{strings.noDataForMonth}</div>
-      ) : (
-        <div className={styles.listsGrid}>
-          <div className={styles.listSection}>
-            <h2 className={styles.listHeading}>{strings.topArtists}</h2>
-            <div className={styles.rankedList}>
-              {topArtists.map((artist, i) => (
-                <div key={artist.name} className={styles.rankedItem}>
-                  <span className={styles.rankNumber}>{i + 1}</span>
-                  <div className={styles.rankInfo}>
-                    <Link
-                      href={`/artists/${artist.name}`}
-                      className={styles.rankName}
-                    >
-                      {artist.name}
-                    </Link>
-                  </div>
-                  <span className={styles.rankCount}>
-                    {artist.playCount} {strings.playsLabel}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className={styles.listSection}>
-            <h2 className={styles.listHeading}>{strings.topSongs}</h2>
-            <div className={styles.rankedList}>
-              {topSongs.map((song, i) => (
-                <div
-                  key={`${song.title}-${song.artist}`}
-                  className={styles.rankedItem}
-                >
-                  <span className={styles.rankNumber}>{i + 1}</span>
-                  <div className={styles.rankInfo}>
-                    <Link
-                      href={`/artists/${song.artist}/${encodeURIComponent(song.title)}`}
-                      className={styles.rankName}
-                    >
-                      {song.title}
-                    </Link>
-                    <div className={styles.rankArtist}>
-                      <Link
-                        href={`/artists/${song.artist}`}
-                        style={{
-                          color: "inherit",
-                          textDecoration: "none",
-                        }}
-                      >
-                        {song.artist}
-                      </Link>
-                    </div>
-                  </div>
-                  <span className={styles.rankCount}>
-                    {song.playCount} {strings.playsLabel}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
+      <Suspense key={suspenseKey} fallback={<ChartResultsSkeleton />}>
+        <ChartResults
+          year={year}
+          month={month}
+          selectedSlugs={selectedSlugs}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/packages/web-ui/styles/loading.css.ts
+++ b/packages/web-ui/styles/loading.css.ts
@@ -1,15 +1,16 @@
 import { style, keyframes } from "@vanilla-extract/css";
 import { vars } from "./theme.css";
 
-const pulse = keyframes({
-  "0%, 100%": { opacity: 1 },
-  "50%": { opacity: 0.4 },
+const shimmer = keyframes({
+  "0%": { backgroundPosition: "-200% 0" },
+  "100%": { backgroundPosition: "200% 0" },
 });
 
 const skeleton = style({
-  backgroundColor: vars.color.border,
   borderRadius: vars.radius.sm,
-  animation: `${pulse} 1.5s ease-in-out infinite`,
+  background: `linear-gradient(90deg, ${vars.color.border} 25%, ${vars.color.bgHover} 50%, ${vars.color.border} 75%)`,
+  backgroundSize: "200% 100%",
+  animation: `${shimmer} 1.8s ease-in-out infinite`,
 });
 
 export const skeletonHeading = style([


### PR DESCRIPTION
## Summary
- Split chart results into a `ChartResults` server component wrapped in `<Suspense>` so the month picker and station filters stay visible while data loads
- Added a content-aware skeleton (`ChartResultsSkeleton`) that mirrors the actual chart layout with rank numbers and shimmer bars
- Replaced the pulse (opacity fade) skeleton animation with a shimmer gradient sweep across all loading states app-wide

## Test plan
- [x] Clicking month arrows / station filters shows skeleton only in the results area, controls remain interactive
- [x] Skeleton layout matches the real chart structure (two columns, 10 ranked items each)
- [x] Shimmer animation works on all existing loading.tsx skeletons
- [x] Builds and type-checks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)