### PR TITLE
Redesign artists page with featured + leaderboard layout

### DIFF
--- a/packages/web-ui/app/artists/loading.tsx
+++ b/packages/web-ui/app/artists/loading.tsx
@@ -1,15 +1,58 @@
 import * as skeleton from "@/styles/loading.css";
+import * as styles from "@/styles/artists.css";
 
 export default function Loading() {
   return (
     <div>
       <div className={skeleton.skeletonHeading} />
+
+      {/* Featured section skeleton */}
+      <div className={styles.featuredSection}>
+        <div className={styles.featuredHeader}>
+          <div
+            className={skeleton.skeletonRow}
+            style={{ width: "140px", margin: 0 }}
+          />
+          <div
+            className={skeleton.skeletonRow}
+            style={{ width: "100px", margin: 0 }}
+          />
+        </div>
+        <div className={styles.featuredGrid}>
+          {[0, 1].map((col) => (
+            <div key={col} className={styles.featuredCard}>
+              {Array.from({ length: col === 0 ? 3 : 2 }, (_, i) => (
+                <div
+                  key={i}
+                  className={skeleton.skeletonRow}
+                  style={{ height: "32px" }}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Leaderboard header skeleton */}
+      <div className={styles.leaderboardHeader}>
+        <div
+          className={skeleton.skeletonRow}
+          style={{ width: "100px", margin: 0 }}
+        />
+        <div
+          className={skeleton.skeletonRow}
+          style={{ width: "50px", margin: 0 }}
+        />
+      </div>
+
       <div className={skeleton.skeletonSearch} />
-      {Array.from({ length: 12 }, (_, i) => (
+
+      {/* Leaderboard rows skeleton */}
+      {Array.from({ length: 10 }, (_, i) => (
         <div
           key={i}
           className={skeleton.skeletonRow}
-          style={{ width: `${60 + Math.random() * 30}%` }}
+          style={{ height: "44px" }}
         />
       ))}
     </div>

--- a/packages/web-ui/app/artists/page.tsx
+++ b/packages/web-ui/app/artists/page.tsx
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import Link from "next/link";
-import { searchArtists, getArtistCount, getArtistPlayCounts } from "@/utils/database";
+import {
+  getTopArtistsForMonth,
+  getTopArtistsAllTime,
+  getArtistCountWithPlays,
+} from "@/utils/database";
 import { heading } from "@/styles/typography.css";
 import * as styles from "@/styles/artists.css";
 import { strings } from "@/utils/strings";
@@ -19,25 +23,95 @@ const paramsSchema = z
   })
   .optional();
 
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
 export default async function ArtistsPage(props: Props) {
   const parsed = paramsSchema.safeParse(props.searchParams);
   const page = parsed.success ? parsed.data?.page ?? 0 : 0;
   const query = parsed.success ? parsed.data?.q : undefined;
   const offset = page * PAGE_SIZE;
+  const isSearching = !!query;
 
-  const [artists, totalCount] = await Promise.all([
-    searchArtists(query, offset, PAGE_SIZE),
-    getArtistCount(query),
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1;
+
+  const [leaderboard, totalCount, featuredArtists] = await Promise.all([
+    getTopArtistsAllTime(offset, PAGE_SIZE, query),
+    getArtistCountWithPlays(query),
+    isSearching
+      ? Promise.resolve([])
+      : getTopArtistsForMonth(currentYear, currentMonth, 5),
   ]);
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
-  const artistIds = artists?.map((a) => a.id) ?? [];
-  const playCounts = artistIds.length > 0 ? await getArtistPlayCounts(artistIds) : {};
-
   return (
     <div>
       <h1 className={heading}>{strings.artists}</h1>
+
+      {!isSearching && featuredArtists.length > 0 && (
+        <div className={styles.featuredSection}>
+          <div className={styles.featuredHeader}>
+            <span className={styles.featuredTitle}>Top this month</span>
+            <span className={styles.featuredMonthLabel}>
+              {MONTH_NAMES[currentMonth - 1]} {currentYear}
+            </span>
+          </div>
+          <div className={styles.featuredGrid}>
+            <div className={styles.featuredCard}>
+              <div className={styles.featuredList}>
+                {featuredArtists.slice(0, 3).map((artist, i) => (
+                  <div key={artist.name} className={styles.featuredItem}>
+                    <span className={styles.featuredRank}>{i + 1}</span>
+                    <Link
+                      href={`/artists/${artist.name}`}
+                      className={styles.featuredName}
+                    >
+                      {artist.name}
+                    </Link>
+                    <span className={styles.featuredCount}>
+                      {artist.playCount.toLocaleString("en-US")}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            {featuredArtists.length > 3 && (
+              <div className={styles.featuredCard}>
+                <div className={styles.featuredList}>
+                  {featuredArtists.slice(3).map((artist, i) => (
+                    <div key={artist.name} className={styles.featuredItem}>
+                      <span className={styles.featuredRank}>{i + 4}</span>
+                      <Link
+                        href={`/artists/${artist.name}`}
+                        className={styles.featuredName}
+                      >
+                        {artist.name}
+                      </Link>
+                      <span className={styles.featuredCount}>
+                        {artist.playCount.toLocaleString("en-US")}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.leaderboardHeader}>
+        <span className={styles.leaderboardTitle}>
+          All artists
+        </span>
+        <span className={styles.leaderboardCount}>
+          {totalCount.toLocaleString("en-US")}
+        </span>
+      </div>
 
       <form action="/artists" method="GET" className={styles.searchForm}>
         <input
@@ -49,16 +123,21 @@ export default async function ArtistsPage(props: Props) {
         />
       </form>
 
-      {artists && artists.length > 0 ? (
-        <div className={styles.artistList}>
-          {artists.map(({ id, name }) => (
-            <Link href={`/artists/${name}`} key={id} className={styles.artistRow}>
-              <span className={styles.artistName}>{name}</span>
-              {playCounts[id] != null && playCounts[id] > 0 && (
-                <span className={styles.playCountBadge}>
-                  {playCounts[id].toLocaleString("en-US")} {strings.playsLabel}
-                </span>
-              )}
+      {leaderboard.length > 0 ? (
+        <div className={styles.leaderboardList}>
+          {leaderboard.map((artist, i) => (
+            <Link
+              href={`/artists/${artist.name}`}
+              key={artist.id}
+              className={styles.leaderboardRow}
+            >
+              <span className={styles.leaderboardRank}>
+                {(offset + i + 1).toLocaleString("en-US")}
+              </span>
+              <span className={styles.leaderboardName}>{artist.name}</span>
+              <span className={styles.leaderboardPlayCount}>
+                {artist.playCount.toLocaleString("en-US")}
+              </span>
             </Link>
           ))}
         </div>

--- a/packages/web-ui/styles/artists.css.ts
+++ b/packages/web-ui/styles/artists.css.ts
@@ -1,6 +1,17 @@
 import { style } from "@vanilla-extract/css";
 import { vars } from "./theme.css";
 
+export const header = style({
+  marginBottom: vars.space["6"],
+});
+
+export const resultCount = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+  marginTop: vars.space["1"],
+});
+
 export const searchForm = style({
   marginBottom: vars.space["6"],
 });
@@ -15,51 +26,14 @@ export const searchInput = style({
   backgroundColor: vars.color.bgSurface,
   color: vars.color.textPrimary,
   outline: "none",
-  transition: "border-color 150ms ease",
+  transition: "border-color 150ms ease, box-shadow 150ms ease",
   "::placeholder": {
     color: vars.color.textMuted,
   },
   ":focus": {
     borderColor: vars.color.accent,
+    boxShadow: `0 0 0 3px ${vars.color.accentLight}`,
   },
-});
-
-export const artistList = style({
-  display: "flex",
-  flexDirection: "column",
-});
-
-export const artistRow = style({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
-  padding: `${vars.space["3"]} ${vars.space["4"]}`,
-  fontSize: vars.fontSize.base,
-  fontFamily: vars.font.body,
-  color: vars.color.textPrimary,
-  textDecoration: "none",
-  borderRadius: vars.radius.sm,
-  transition: "background-color 150ms ease, transform 150ms ease",
-  ":hover": {
-    backgroundColor: vars.color.bgHover,
-    transform: "translateX(2px)",
-  },
-});
-
-export const artistName = style({
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-  minWidth: 0,
-});
-
-export const playCountBadge = style({
-  fontSize: vars.fontSize.xs,
-  fontFamily: vars.font.body,
-  fontWeight: 600,
-  color: vars.color.textMuted,
-  flexShrink: 0,
-  marginLeft: vars.space["3"],
 });
 
 export const emptyState = style({
@@ -68,4 +42,181 @@ export const emptyState = style({
   color: vars.color.textSecondary,
   fontFamily: vars.font.body,
   fontSize: vars.fontSize.base,
+});
+
+// Featured section
+export const featuredSection = style({
+  marginBottom: vars.space["8"],
+});
+
+export const featuredHeader = style({
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  marginBottom: vars.space["4"],
+});
+
+export const featuredTitle = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  letterSpacing: "-0.02em",
+});
+
+export const featuredMonthLabel = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});
+
+export const featuredGrid = style({
+  display: "grid",
+  gridTemplateColumns: "1fr",
+  gap: vars.space["4"],
+  "@media": {
+    "(min-width: 640px)": {
+      gridTemplateColumns: "1fr 1fr",
+    },
+  },
+});
+
+export const featuredCard = style({
+  backgroundColor: vars.color.bgSurface,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space["4"],
+});
+
+export const featuredList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: 0,
+});
+
+export const featuredItem = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space["3"],
+  padding: `${vars.space["2"]} 0`,
+  borderBottom: `1px solid ${vars.color.border}`,
+  selectors: {
+    "&:last-child": {
+      borderBottom: "none",
+    },
+  },
+});
+
+export const featuredRank = style({
+  fontSize: vars.fontSize["2xl"],
+  fontFamily: vars.font.body,
+  fontWeight: 700,
+  color: vars.color.border,
+  minWidth: "28px",
+  textAlign: "right",
+  lineHeight: 1,
+});
+
+export const featuredName = style({
+  flex: 1,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  textDecoration: "none",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  transition: "color 150ms ease",
+  ":hover": {
+    color: vars.color.accent,
+  },
+});
+
+export const featuredCount = style({
+  fontSize: vars.fontSize.xs,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textSecondary,
+  backgroundColor: vars.color.bgHover,
+  padding: `${vars.space["1"]} ${vars.space["2"]}`,
+  borderRadius: vars.radius.sm,
+  whiteSpace: "nowrap",
+  flexShrink: 0,
+});
+
+// Leaderboard section
+export const leaderboardHeader = style({
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  marginBottom: vars.space["4"],
+});
+
+export const leaderboardTitle = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  letterSpacing: "-0.02em",
+});
+
+export const leaderboardCount = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});
+
+export const leaderboardList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: 0,
+});
+
+export const leaderboardRow = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space["3"],
+  padding: `${vars.space["3"]} ${vars.space["2"]}`,
+  borderBottom: `1px solid ${vars.color.border}`,
+  textDecoration: "none",
+  transition: "background-color 150ms ease",
+  ":hover": {
+    backgroundColor: vars.color.bgHover,
+  },
+  selectors: {
+    "&:last-child": {
+      borderBottom: "none",
+    },
+  },
+});
+
+export const leaderboardRank = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textMuted,
+  minWidth: "32px",
+  textAlign: "right",
+  flexShrink: 0,
+});
+
+export const leaderboardName = style({
+  flex: 1,
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+export const leaderboardPlayCount = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textSecondary,
+  whiteSpace: "nowrap",
+  flexShrink: 0,
 });

--- a/packages/web-ui/utils/database.ts
+++ b/packages/web-ui/utils/database.ts
@@ -569,6 +569,36 @@ export async function getArtistPlayCounts(
   return counts;
 }
 
+export async function getTopArtistsAllTime(
+  offset: number,
+  limit: number,
+  search?: string
+): Promise<{ id: number; name: string; playCount: number }[]> {
+  const { data, error } = await getSupabase().rpc("top_artists_all_time", {
+    p_limit: limit,
+    p_offset: offset,
+    p_search: search || null,
+  });
+
+  if (error) throw error;
+  return (data ?? []).map((row: any) => ({
+    id: row.artist_id,
+    name: row.artist_name,
+    playCount: row.play_count,
+  }));
+}
+
+export async function getArtistCountWithPlays(
+  search?: string
+): Promise<number> {
+  const { data, error } = await getSupabase().rpc("artist_count_with_plays", {
+    p_search: search || null,
+  });
+
+  if (error) throw error;
+  return (data as number) ?? 0;
+}
+
 export async function getEarliestPlayDate() {
   const { data, error } = await getSupabase()
     .from("plays")

--- a/supabase/migrations/005_add_top_artists_all_time.sql
+++ b/supabase/migrations/005_add_top_artists_all_time.sql
@@ -1,0 +1,37 @@
+-- Top artists all time, sorted by play count, with optional search and pagination
+create or replace function top_artists_all_time(
+  p_limit int default 30,
+  p_offset int default 0,
+  p_search text default null
+)
+returns table(artist_id bigint, artist_name text, play_count bigint)
+language sql stable
+as $$
+  select a.id as artist_id, a.name as artist_name, count(*) as play_count
+  from plays p
+  join songs s on s.id = p.song_id
+  join artists a on a.id = s.artist_id
+  where p.is_deleted = false
+    and p.is_likely_not_music = false
+    and (p_search is null or a.name ilike '%' || p_search || '%')
+  group by a.id, a.name
+  order by play_count desc
+  limit p_limit
+  offset p_offset;
+$$;
+
+-- Count of artists that have at least one play, with optional search
+create or replace function artist_count_with_plays(
+  p_search text default null
+)
+returns bigint
+language sql stable
+as $$
+  select count(distinct a.id)
+  from plays p
+  join songs s on s.id = p.song_id
+  join artists a on a.id = s.artist_id
+  where p.is_deleted = false
+    and p.is_likely_not_music = false
+    and (p_search is null or a.name ilike '%' || p_search || '%');
+$$;


### PR DESCRIPTION
## Summary
- Replace flat alphabetical artist list with a hybrid layout: "Top this month" featured section + all-time leaderboard ranked by play count
- Add two new RPC functions (`top_artists_all_time`, `artist_count_with_plays`) for paginated, searchable leaderboard
- Search hides featured section and filters the leaderboard; pagination works across the full catalog
- Updated loading skeleton to match new layout

## Test plan
- [ ] Visit `/artists` — featured section shows top 5 artists for the current month, leaderboard shows all artists ranked by plays
- [ ] Search filters the leaderboard and hides featured section
- [ ] Pagination navigates through the full artist catalog
- [ ] Mobile responsive — featured section stacks to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)