### PR TITLE
Backfill non-music flags and tighten detection

### DIFF
--- a/packages/scraper/src/isLikelyAd.ts
+++ b/packages/scraper/src/isLikelyAd.ts
@@ -1,7 +1,8 @@
 const PHONE_NUMBER = /\d{6,}/;
 const WEB_DOMAIN = /\.(fo|dk|com|net|org|is)\b/i;
 const TLF = /\btlf\b/i;
-const STATION_NAMES = /\b(kvf|kvf2|aldan|alduni|kringvarp|rás?\s*2)\b/i;
+const STATION_NAMES = /\b(alduni|kringvarp|rás?\s*2)\b/i;
+const STATION_NAMES_ARTIST_ONLY = /\b(aldan|kvf|kvf2)\b/i;
 const DATE_IN_TITLE = /\d{2}\.\d{2}\.\d{2,4}/;
 const ELECTION = /\bvalevni\b/i;
 const FESTIVAL_PROMO = /\bsummarfestival/i;
@@ -9,6 +10,7 @@ const FESTIVAL_PROMO = /\bsummarfestival/i;
 export const isLikelyNotMusic = (artist: string, title: string): boolean => {
   if (artist.toLowerCase() === 'artist' && title.toLowerCase() === 'title') return true;
   if (DATE_IN_TITLE.test(title)) return true;
+  if (STATION_NAMES_ARTIST_ONLY.test(artist)) return true;
   const combined = `${artist} ${title}`;
   return (
     PHONE_NUMBER.test(combined) ||

--- a/packages/scraper/src/isLikelyAd.ts
+++ b/packages/scraper/src/isLikelyAd.ts
@@ -3,6 +3,8 @@ const WEB_DOMAIN = /\.(fo|dk|com|net|org|is)\b/i;
 const TLF = /\btlf\b/i;
 const STATION_NAMES = /\b(kvf|kvf2|aldan|alduni|kringvarp|rás?\s*2)\b/i;
 const DATE_IN_TITLE = /\d{2}\.\d{2}\.\d{2,4}/;
+const ELECTION = /\bvalevni\b/i;
+const FESTIVAL_PROMO = /\bsummarfestival/i;
 
 export const isLikelyNotMusic = (artist: string, title: string): boolean => {
   if (artist.toLowerCase() === 'artist' && title.toLowerCase() === 'title') return true;
@@ -12,6 +14,8 @@ export const isLikelyNotMusic = (artist: string, title: string): boolean => {
     PHONE_NUMBER.test(combined) ||
     WEB_DOMAIN.test(combined) ||
     TLF.test(combined) ||
-    STATION_NAMES.test(combined)
+    STATION_NAMES.test(combined) ||
+    ELECTION.test(combined) ||
+    FESTIVAL_PROMO.test(combined)
   );
 };

--- a/supabase/migrations/20260321170000_backfill_non_music_flags.sql
+++ b/supabase/migrations/20260321170000_backfill_non_music_flags.sql
@@ -1,0 +1,28 @@
+-- Backfill is_likely_not_music for all historical plays using the same
+-- detection patterns as the scraper's isLikelyNotMusic function.
+-- This covers all data inserted before the detection was deployed (March 17, 2026).
+
+UPDATE plays
+SET is_likely_not_music = true
+FROM songs s
+JOIN artists a ON a.id = s.artist_id
+WHERE plays.song_id = s.id
+  AND plays.is_likely_not_music = false
+  AND (
+    -- Placeholder values
+    (lower(a.name) = 'artist' AND lower(s.title) = 'title')
+    -- Date in title (e.g. "21.03.2026")
+    OR s.title ~ '\d{2}\.\d{2}\.\d{2,4}'
+    -- Phone numbers (6+ digits)
+    OR (a.name || ' ' || s.title) ~ '\d{6,}'
+    -- Web domains
+    OR (a.name || ' ' || s.title) ~* '\.(fo|dk|com|net|org|is)\y'
+    -- "tlf" keyword
+    OR (a.name || ' ' || s.title) ~* '\mtlf\M'
+    -- Station names
+    OR (a.name || ' ' || s.title) ~* '\m(kvf|kvf2|aldan|alduni|kringvarp|rás\s*2)\M'
+    -- Election content
+    OR (a.name || ' ' || s.title) ~* '\mvalevni\M'
+    -- Festival promos
+    OR (a.name || ' ' || s.title) ~* '\msummarfestival'
+  );

--- a/supabase/migrations/20260321170000_backfill_non_music_flags.sql
+++ b/supabase/migrations/20260321170000_backfill_non_music_flags.sql
@@ -19,8 +19,10 @@ WHERE plays.song_id = s.id
     OR (a.name || ' ' || s.title) ~* '\.(fo|dk|com|net|org|is)\y'
     -- "tlf" keyword
     OR (a.name || ' ' || s.title) ~* '\mtlf\M'
-    -- Station names
-    OR (a.name || ' ' || s.title) ~* '\m(kvf|kvf2|aldan|alduni|kringvarp|rás\s*2)\M'
+    -- Station names (unambiguous — check both artist and title)
+    OR (a.name || ' ' || s.title) ~* '\m(alduni|kringvarp|rás\s*2)\M'
+    -- Station names (ambiguous — only check artist to avoid false positives)
+    OR a.name ~* '\m(aldan|kvf|kvf2)\M'
     -- Election content
     OR (a.name || ' ' || s.title) ~* '\mvalevni\M'
     -- Festival promos


### PR DESCRIPTION
## Summary
- Backfill migration applying all `isLikelyNotMusic` patterns to historical plays
- Tightened station name matching: "aldan" and "kvf" only checked in artist field to avoid false positives on real songs
- Added new detection patterns for election content (`valevni`) and festival promos (`summarfestival`)

## Test plan
- [x] Dry-run SELECT verified correct matches and no false positives
- [x] Migration applied to production via `apply_migration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)