### PR TITLE
Add songs overview to artist detail page

### DIFF
--- a/packages/web-ui/app/artists/[slug]/page.tsx
+++ b/packages/web-ui/app/artists/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   getArtistPlays,
   getArtistPlayCount,
   getArtistStationBreakdown,
+  getArtistSongsOverview,
 } from "@/utils/database";
 import format from "date-fns/format";
 import { heading } from "@/styles/typography.css";
@@ -33,11 +34,13 @@ export default async function ArtistPage({
   const page = parsed.success ? parsed.data?.page ?? 0 : 0;
   const offset = page * PAGE_SIZE;
 
-  const [plays, totalCount, stationBreakdown] = await Promise.all([
-    getArtistPlays(artistName, offset, PAGE_SIZE),
-    getArtistPlayCount(artistName),
-    getArtistStationBreakdown(artistName),
-  ]);
+  const [plays, totalCount, stationBreakdown, songsOverview] =
+    await Promise.all([
+      getArtistPlays(artistName, offset, PAGE_SIZE),
+      getArtistPlayCount(artistName),
+      getArtistStationBreakdown(artistName),
+      getArtistSongsOverview(artistName),
+    ]);
 
   if (plays === null || totalCount === null) {
     notFound();
@@ -73,6 +76,41 @@ export default async function ArtistPage({
           ))}
         </div>
       )}
+
+      {songsOverview && songsOverview.length > 0 && (
+        <div>
+          <h2 className={styles.sectionHeading}>
+            {strings.songs} ({songsOverview.length})
+          </h2>
+          <div className={styles.songsOverviewGrid}>
+            {songsOverview.map(
+              ({ songId, title, playCount, firstPlayed, lastPlayed }) => (
+                <Link
+                  key={songId}
+                  href={`/artists/${params.slug}/${encodeURIComponent(title)}`}
+                  className={styles.songCard}
+                >
+                  <div className={styles.songCardTitle}>{title}</div>
+                  <div className={styles.songCardStats}>
+                    <span className={styles.songCardPlayCount}>
+                      {playCount.toLocaleString("en-US")}{" "}
+                      {playCount === 1 ? strings.play : strings.playsLabel}
+                    </span>
+                    <span className={styles.songCardStat}>
+                      First played: {format(new Date(firstPlayed), "MMM d, yyyy")}
+                    </span>
+                    <span className={styles.songCardStat}>
+                      Last played: {format(new Date(lastPlayed), "MMM d, yyyy")}
+                    </span>
+                  </div>
+                </Link>
+              )
+            )}
+          </div>
+        </div>
+      )}
+
+      <h2 className={styles.sectionHeading}>Recent plays</h2>
 
       <table className={styles.table}>
         <thead>

--- a/packages/web-ui/app/artists/[slug]/page.tsx
+++ b/packages/web-ui/app/artists/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   getArtistSongsOverview,
 } from "@/utils/database";
 import format from "date-fns/format";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import { heading } from "@/styles/typography.css";
 import * as styles from "@/styles/artist-detail.css";
 import { strings } from "@/utils/strings";
@@ -82,30 +83,96 @@ export default async function ArtistPage({
           <h2 className={styles.sectionHeading}>
             {strings.songs} ({songsOverview.length})
           </h2>
-          <div className={styles.songsOverviewGrid}>
-            {songsOverview.map(
-              ({ songId, title, playCount, firstPlayed, lastPlayed }) => (
-                <Link
-                  key={songId}
-                  href={`/artists/${params.slug}/${encodeURIComponent(title)}`}
-                  className={styles.songCard}
-                >
-                  <div className={styles.songCardTitle}>{title}</div>
-                  <div className={styles.songCardStats}>
-                    <span className={styles.songCardPlayCount}>
-                      {playCount.toLocaleString("en-US")}{" "}
-                      {playCount === 1 ? strings.play : strings.playsLabel}
-                    </span>
-                    <span className={styles.songCardStat}>
-                      First played: {format(new Date(firstPlayed), "MMM d, yyyy")}
-                    </span>
-                    <span className={styles.songCardStat}>
-                      Last played: {format(new Date(lastPlayed), "MMM d, yyyy")}
-                    </span>
-                  </div>
-                </Link>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th className={styles.th}>{strings.title}</th>
+                <th className={styles.thRight}>{strings.plays}</th>
+                <th className={styles.th}>First played</th>
+                <th className={styles.th}>Last played</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...songsOverview]
+                .sort(
+                  (a, b) =>
+                    new Date(b.lastPlayed).getTime() -
+                    new Date(a.lastPlayed).getTime()
+                )
+                .map(
+                  ({ songId, title, playCount, firstPlayed, lastPlayed }) => (
+                    <tr key={songId}>
+                      <td className={styles.td}>
+                        <Link
+                          href={`/artists/${params.slug}/${encodeURIComponent(title)}`}
+                          className={styles.songLink}
+                        >
+                          {title}
+                        </Link>
+                      </td>
+                      <td className={styles.tdRight}>
+                        {playCount.toLocaleString("en-US")}
+                      </td>
+                      <td
+                        className={styles.tdTime}
+                        title={format(
+                          new Date(firstPlayed),
+                          "MMM d, yyyy 'at' h:mm a"
+                        )}
+                      >
+                        {formatDistanceToNow(new Date(firstPlayed), {
+                          addSuffix: true,
+                        })}
+                      </td>
+                      <td
+                        className={styles.tdTime}
+                        title={format(
+                          new Date(lastPlayed),
+                          "MMM d, yyyy 'at' h:mm a"
+                        )}
+                      >
+                        {formatDistanceToNow(new Date(lastPlayed), {
+                          addSuffix: true,
+                        })}
+                      </td>
+                    </tr>
+                  )
+                )}
+            </tbody>
+          </table>
+
+          <div className={styles.mobileList}>
+            {[...songsOverview]
+              .sort(
+                (a, b) =>
+                  new Date(b.lastPlayed).getTime() -
+                  new Date(a.lastPlayed).getTime()
               )
-            )}
+              .map(
+                ({ songId, title, playCount, firstPlayed, lastPlayed }) => (
+                  <div key={songId} className={styles.mobileCard}>
+                    <Link
+                      href={`/artists/${params.slug}/${encodeURIComponent(title)}`}
+                      className={styles.mobileTitle}
+                    >
+                      {title}
+                    </Link>
+                    <div className={styles.mobileMeta}>
+                      <span>
+                        {playCount.toLocaleString("en-US")}{" "}
+                        {playCount === 1 ? strings.play : strings.playsLabel}
+                      </span>
+                      <span
+                        title={`${format(new Date(firstPlayed), "MMM d, yyyy")} – ${format(new Date(lastPlayed), "MMM d, yyyy")}`}
+                      >
+                        {formatDistanceToNow(new Date(lastPlayed), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    </div>
+                  </div>
+                )
+              )}
           </div>
         </div>
       )}

--- a/packages/web-ui/styles/artist-detail.css.ts
+++ b/packages/web-ui/styles/artist-detail.css.ts
@@ -98,6 +98,60 @@ export const mobileCard = style({
   padding: vars.space["4"],
 });
 
+export const sectionHeading = style({
+  fontSize: vars.fontSize.lg,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space["4"],
+});
+
+export const songsOverviewGrid = style({
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
+  gap: vars.space["3"],
+  marginBottom: vars.space["8"],
+});
+
+export const songCard = style({
+  backgroundColor: vars.color.bgSurface,
+  border: `1px solid ${vars.color.border}`,
+  borderRadius: vars.radius.md,
+  padding: vars.space["4"],
+  textDecoration: "none",
+  transition: "border-color 150ms ease",
+  ":hover": {
+    borderColor: vars.color.accent,
+  },
+});
+
+export const songCardTitle = style({
+  fontSize: vars.fontSize.base,
+  fontFamily: vars.font.body,
+  fontWeight: 500,
+  color: vars.color.textPrimary,
+  marginBottom: vars.space["2"],
+});
+
+export const songCardStats = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space["1"],
+});
+
+export const songCardStat = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  color: vars.color.textSecondary,
+});
+
+export const songCardPlayCount = style({
+  fontSize: vars.fontSize.sm,
+  fontFamily: vars.font.body,
+  fontWeight: 600,
+  color: vars.color.accent,
+});
+
 export const songLink = style({
   color: vars.color.textPrimary,
   textDecoration: "none",

--- a/packages/web-ui/styles/artist-detail.css.ts
+++ b/packages/web-ui/styles/artist-detail.css.ts
@@ -103,54 +103,29 @@ export const sectionHeading = style({
   fontFamily: vars.font.body,
   fontWeight: 600,
   color: vars.color.textPrimary,
+  marginTop: vars.space["12"],
   marginBottom: vars.space["4"],
-});
-
-export const songsOverviewGrid = style({
-  display: "grid",
-  gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-  gap: vars.space["3"],
-  marginBottom: vars.space["8"],
-});
-
-export const songCard = style({
-  backgroundColor: vars.color.bgSurface,
-  border: `1px solid ${vars.color.border}`,
-  borderRadius: vars.radius.md,
-  padding: vars.space["4"],
-  textDecoration: "none",
-  transition: "border-color 150ms ease",
-  ":hover": {
-    borderColor: vars.color.accent,
+  selectors: {
+    "&:first-child": {
+      marginTop: 0,
+    },
   },
 });
 
-export const songCardTitle = style({
-  fontSize: vars.fontSize.base,
-  fontFamily: vars.font.body,
-  fontWeight: 500,
-  color: vars.color.textPrimary,
-  marginBottom: vars.space["2"],
-});
+export const thRight = style([
+  th,
+  {
+    textAlign: "right",
+  },
+]);
 
-export const songCardStats = style({
-  display: "flex",
-  flexDirection: "column",
-  gap: vars.space["1"],
-});
-
-export const songCardStat = style({
-  fontSize: vars.fontSize.sm,
-  fontFamily: vars.font.body,
-  color: vars.color.textSecondary,
-});
-
-export const songCardPlayCount = style({
-  fontSize: vars.fontSize.sm,
-  fontFamily: vars.font.body,
-  fontWeight: 600,
-  color: vars.color.accent,
-});
+export const tdRight = style([
+  td,
+  {
+    textAlign: "right",
+    fontVariantNumeric: "tabular-nums",
+  },
+]);
 
 export const songLink = style({
   color: vars.color.textPrimary,

--- a/packages/web-ui/utils/database.ts
+++ b/packages/web-ui/utils/database.ts
@@ -272,6 +272,35 @@ export async function getArtistStationBreakdown(
   }));
 }
 
+export async function getArtistSongsOverview(
+  artistName: string
+): Promise<
+  | {
+      songId: number;
+      title: string;
+      playCount: number;
+      firstPlayed: string;
+      lastPlayed: string;
+    }[]
+  | null
+> {
+  const artistId = await findArtistId(artistName);
+  if (artistId === null) return null;
+
+  const { data, error } = await getSupabase().rpc("artist_songs_overview", {
+    p_artist_id: artistId,
+  });
+
+  if (error) throw error;
+  return (data ?? []).map((row: any) => ({
+    songId: row.song_id,
+    title: row.title,
+    playCount: row.play_count,
+    firstPlayed: row.first_played,
+    lastPlayed: row.last_played,
+  }));
+}
+
 export async function getArtistPlayCount(artistName: string) {
   const artistId = await findArtistId(artistName);
   if (artistId === null) return null;

--- a/supabase/migrations/20260329120000_add_artist_songs_overview.sql
+++ b/supabase/migrations/20260329120000_add_artist_songs_overview.sql
@@ -1,0 +1,26 @@
+create or replace function artist_songs_overview(p_artist_id bigint)
+returns table (
+  song_id bigint,
+  title text,
+  play_count bigint,
+  first_played timestamptz,
+  last_played timestamptz
+)
+language sql
+stable
+set search_path = ''
+as $$
+  select
+    s.id as song_id,
+    s.title,
+    count(p.id) as play_count,
+    min(p.time_played) as first_played,
+    max(p.time_played) as last_played
+  from public.songs s
+  inner join public.plays p on p.song_id = s.id
+  where s.artist_id = p_artist_id
+    and p.is_deleted = false
+    and p.is_likely_not_music = false
+  group by s.id, s.title
+  order by play_count desc, s.title asc;
+$$;


### PR DESCRIPTION
## Summary
- Add `artist_songs_overview` RPC function returning per-song stats (play count, first/last played)
- Show a songs table on the artist detail page, sorted by most recently played
- Display relative timestamps (e.g. "2 days ago") with full date on hover
- Responsive: table on desktop, cards on mobile

## Test plan
- [ ] Visit an artist page and verify the songs table appears with correct data
- [ ] Hover over timestamps to see full dates
- [ ] Check mobile layout renders cards instead of table
- [ ] Verify song links navigate to the correct song detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)