### PR TITLE
Grant actions: write so recovery clears alert markers

### DIFF
--- a/.github/workflows/no-writes-check.yml
+++ b/.github/workflows/no-writes-check.yml
@@ -5,6 +5,13 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+# actions: write is required for `gh cache delete` to clear alert markers on
+# recovery. Without it the deletes 403, markers linger, and every successful
+# run re-sends a "recovered" email.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The workflow sent a "✅ recovered" email **every hour even when nothing was broken**.

Evidence from a recent run's log:
```
Prior alert keys found: alert-sent-kvf
subject: ✅ Radio scraper recovered...
Deleting cache: alert-sent-kvf
X Failed to delete cache: HTTP 403: Resource not accessible by integration
```

The recovery step clears `alert-sent-*` caches with `gh cache delete`, which needs `actions: write`. The default `GITHUB_TOKEN` is read-only, so the deletes 403'd (hidden by `|| true`). The markers never cleared, so every successful run re-detected them and re-sent "recovered."

## Fix

Add a workflow `permissions` block granting `actions: write` (+ `contents: read`) so the deletes succeed and recovery fires once per incident.

Also deleted the two lingering markers (`alert-sent-kvf`, `alert-sent-kvf-kvf2`) manually, so the spam stops immediately rather than after the next run.

## Note

If deletes still 403 after this, the repo's **Settings → Actions → General → Workflow permissions** is forcing read-only and needs "Read and write permissions" — but the per-workflow block should be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)